### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/spinup-destroy.yml
+++ b/.github/workflows/spinup-destroy.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Configure Azure environment
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-deploy-to-azure/security/code-scanning/8](https://github.com/SravandeepReddy2004/skills-deploy-to-azure/security/code-scanning/8)

To fix this problem, add a `permissions` block to the root of the `.github/workflows/spinup-destroy.yml` workflow file. This block should be above the `jobs:` key so that it applies to all jobs unless overridden. For this workflow, the minimal permissions recommendation is `contents: read`, since all visible tasks only check out the repo and interact with Azure, with no need for further permissions to the repository or pull requests. No other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
