### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,5 +1,9 @@
 name: Deploy to staging
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   pull_request:
     types: [labeled]


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-deploy-to-azure/security/code-scanning/7](https://github.com/SravandeepReddy2004/skills-deploy-to-azure/security/code-scanning/7)

To address this problem, you should add an explicit `permissions` block to the workflow, at either the root level (applying to all jobs) or to individual jobs. The minimal way is at the workflow root, immediately after `name:` or `on:`. For container publishing tasks and artifact handling, typically only `contents: read` and possibly `packages: write` are needed—for example, to push Docker images to GHCR. For most build/deploy steps, workflow-wide write access to code or issues isn't required; deploying to Azure uses external secrets. 

Specifically:  
- Add a `permissions:` block to the workflow YAML at the root (right after `name:` and before or after `on:`).
- Set only the permissions needed, for example:
  ```yaml
  permissions:
    contents: read
    packages: write
  ```
  If pull-requests or other write actions are needed, add them specifically (none are clearly needed here).
- No changes to imports or functional parts of the workflow.

**Files/lines to change:**  
- Edit `.github/workflows/deploy-staging.yml`
- Insert a `permissions:` block at the top (after `name:` and before or after `on:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
